### PR TITLE
support user-defined schemas

### DIFF
--- a/src/main/java/ru/homyakin/iuliia/Schemas.java
+++ b/src/main/java/ru/homyakin/iuliia/Schemas.java
@@ -1,9 +1,10 @@
 package ru.homyakin.iuliia;
 
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.io.InputStream;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 public enum Schemas {
     ALA_LC("ala_lc.json"),
@@ -42,6 +43,10 @@ public enum Schemas {
 
     public Schema getSchema() throws IOException {
         var stream = getJsonStream(name);
+        return getSchema(stream);
+    }
+
+    public static Schema getSchema(InputStream stream) throws IOException {
         ObjectMapper mapper = new ObjectMapper();
         return mapper.readValue(stream, Schema.class);
     }

--- a/src/main/java/ru/homyakin/iuliia/Translator.java
+++ b/src/main/java/ru/homyakin/iuliia/Translator.java
@@ -20,6 +20,10 @@ public class Translator {
         }
     }
 
+    public Translator(Schema schema) {
+        this.schema = schema;
+    }
+
     public String translate(String str) {
         if (str == null) return null;
         var words = separator.split(str);


### PR DESCRIPTION
Let users work with `Translator` and a custom schema resource without recompiling this library or duplicating code.

