### PR TITLE
[BF] split words correctly in java >= 19

### DIFF
--- a/src/main/java/ru/homyakin/iuliia/Translator.java
+++ b/src/main/java/ru/homyakin/iuliia/Translator.java
@@ -5,7 +5,7 @@ import java.util.regex.Pattern;
 
 public class Translator {
 
-    private final static Pattern separator = Pattern.compile("\\b");
+    private final static Pattern separator = Pattern.compile("(?U:\\b)");
     private final Schema schema;
 
     /**


### PR DESCRIPTION
In Java 19 the behaviour of the word boundary was changed. It only matches ascii per default.
see https://bugs.openjdk.org/browse/JDK-8264160